### PR TITLE
Added example about always test `.send` and pulled out to new section

### DIFF
--- a/smart-contracts.md
+++ b/smart-contracts.md
@@ -89,23 +89,23 @@ There is a slight difference in Solidity as to what happens with Contract calls 
 
 The most important point is the same for both, whether using ExternalContract.doSomething() or address.call(), if ExternalContract is untrusted, assume that malicious code will execute.  Note that if you trust an ExternalContract, you also trust any external contracts it calls, and that those call, are all non-malicious.  If any malicious contract exists in the call chain, the malicious contract can attack you (next section on Reentrant Attacks).
 
-### Always test if `.send` succeeded
+### Always test if `.send` and other raw calls have succeeded
 
-Sends (and raw calls) can fail (e.g., when the call stack depth of 1024 is breached), so you should always test if it succeeded. If you don't test the result, it's recommended to note in a comment.
+Sends and raw external calls can fail (e.g., when the call stack depth of 1024 is breached), so you should always test if it succeeded. If you don't test the result, it's recommended to note in a comment.
 
 Also, if you throw on a `send` failure in an iterator then your loop may never be able to complete.
 
 ```
 // bad
 someAddress.send();
-someAddress.call.value(100000)();
+someAddress.call.value()(); // this is doubly dangerous, as it will forward all remaining gas and doesn't check for result
 
 // good
 if(!someAddress.send()) {
     // Some failure code
 }
 
-if(!someAddress.call.value(100000)()) {
+if(!someAddress.call.value(100000)()) { // forwards fixed amount of gas
     // Some failure code
 }
 ```

--- a/smart-contracts.md
+++ b/smart-contracts.md
@@ -91,7 +91,9 @@ The most important point is the same for both, whether using ExternalContract.do
 
 ### Always test if `.send` succeeded
 
-Sends (and raw calls) can fail (e.g., when the call stack depth of 1024 is breached), so you should always test if it succeeded. Remember also if you throw on a `send` failure in an iterator that your loop may never be able to complete.
+Sends (and raw calls) can fail (e.g., when the call stack depth of 1024 is breached), so you should always test if it succeeded. If you don't test the result, it's recommended to note in a comment.
+
+Also, if you throw on a `send` failure in an iterator then your loop may never be able to complete.
 
 ```
 // bad

--- a/smart-contracts.md
+++ b/smart-contracts.md
@@ -89,19 +89,26 @@ There is a slight difference in Solidity as to what happens with Contract calls 
 
 The most important point is the same for both, whether using ExternalContract.doSomething() or address.call(), if ExternalContract is untrusted, assume that malicious code will execute.  Note that if you trust an ExternalContract, you also trust any external contracts it calls, and that those call, are all non-malicious.  If any malicious contract exists in the call chain, the malicious contract can attack you (next section on Reentrant Attacks).
 
-The return value of all raw external calls should be checked to see if it failed or not.
+### Always test if `.send` succeeded
 
-Explicit comments should be made as to why the return value isn’t checked, if that is desired. Checking this is primarily due to the call depth attack.
-
-Here is an example of checking the return value:
+Sends (and raw calls) can fail (e.g., when the call stack depth of 1024 is breached), so you should always test if it succeeded. Remember also if you throw on a `send` failure in an iterator that your loop may never be able to complete.
 
 ```
-function doSomething() {
-    if(!address.call.value(100000)()) { throw; }
+// bad
+someAddress.send();
+someAddress.call.value(100000)();
+
+// good
+if(!someAddress.send()) {
+    // Some failure code
+}
+
+if(!someAddress.call.value(100000)()) {
+    // Some failure code
 }
 ```
 
-NOTE: beware of this pattern for potentially deadlocking a contract...
+Source: [Smart Contract Security](https://blog.ethereum.org/2016/06/10/smart-contract-security/)
 
 ### Deadlocking Through Forcing Unexpected Throws
 


### PR DESCRIPTION
For *always test send*, I added an example and pulled out to a new section