### PR TITLE
Comment explaining refunds reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ contract auction {
         uint refund = refunds[msg.sender];
         refunds[msg.sender] = 0;
         if (!msg.sender.send(refund)) {
-            refunds[msg.sender] = refund;
+            refunds[msg.sender] = refund; // reverting state changes because send failed
         }
     }
 }


### PR DESCRIPTION
It's not immediate obvious why we are updating `refunds` here. This comment drives home the point that reverting state is preferable to `throw`.