### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ When launching a contract that will have substantial funds or is required to be 
 
 ## Security Tools
 
-- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf), an upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
+- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - An upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ When launching a contract that will have substantial funds or is required to be 
 
 ## Security Tools
 
-- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - An upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
+- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - Another upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ When launching a contract that will have substantial funds or is required to be 
 
 ## Security Tools
 
-- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - Another upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
+- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - An upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 

--- a/README.md
+++ b/README.md
@@ -921,6 +921,8 @@ When launching a contract that will have substantial funds or is required to be 
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 
+- [solint](https://github.com/weifund/solint) - Another upcoming tool, will provide Solidity linting that helps you enforce consistent conventions and avoid errors in your Solidity smart-contracts.
+
 
 
 ## Future improvements

--- a/README.md
+++ b/README.md
@@ -861,7 +861,7 @@ During testing, you can force an automatic deprecation by preventing any actions
 
 ```
 modifier isActive() {
-    if (now > SOME_BLOCK_NUMBER) {
+    if (block.number > SOME_BLOCK_NUMBER) {
         throw;
     }
     _
@@ -917,11 +917,10 @@ When launching a contract that will have substantial funds or is required to be 
 
 ## Security Tools
 
-- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - An upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
+- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf), an upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 
-- [solint](https://github.com/weifund/solint) - Another upcoming tool, will provide Solidity linting that helps you enforce consistent conventions and avoid errors in your Solidity smart-contracts.
 
 
 ## Future improvements

--- a/src/06-SoftwareEngineering.md
+++ b/src/06-SoftwareEngineering.md
@@ -237,7 +237,7 @@ During testing, you can force an automatic deprecation by preventing any actions
 
 ```
 modifier isActive() {
-    if (now > SOME_BLOCK_NUMBER) {
+    if (block.number > SOME_BLOCK_NUMBER) {
         throw;
     }
     _

--- a/src/08-SecurityTools.md
+++ b/src/08-SecurityTools.md
@@ -1,7 +1,7 @@
 
 ## Security Tools
 
-- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - An upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
+- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - Another upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 

--- a/src/08-SecurityTools.md
+++ b/src/08-SecurityTools.md
@@ -1,7 +1,7 @@
 
 ## Security Tools
 
-- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - Another upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
+- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - An upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 

--- a/src/08-SecurityTools.md
+++ b/src/08-SecurityTools.md
@@ -5,4 +5,6 @@
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 
+- [solint](https://github.com/weifund/solint) - Another upcoming tool, will provide Solidity linting that helps you enforce consistent conventions and avoid errors in your Solidity smart-contracts.
+
 

--- a/src/08-SecurityTools.md
+++ b/src/08-SecurityTools.md
@@ -1,7 +1,7 @@
 
 ## Security Tools
 
-- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf), an upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
+- [Oyente](http://www.comp.nus.edu.sg/~loiluu/papers/oyente.pdf) - An upcoming tool, will analyze Ethereum code to find common vulnerabilities (e.g., Transaction Order Dependence, no checking for exceptions)
 
 - [Solgraph](https://github.com/raineorshine/solgraph) - Generates a DOT graph that visualizes function control flow of a Solidity contract and highlights potential security vulnerabilities.
 


### PR DESCRIPTION
Automatic depreciation example compares `now` to a block number.
This fix uses `block.number` instead or `now`.
This also fixes #44 that made changes directly to README, now reflected in `src`