### PR TITLE
"bad" example should refer to Bank, not UntrustedBank

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ When interacting with external contracts, name your variables, methods, and cont
 Bank.withdraw(100); // Unclear whether trusted or untrusted
 
 function makeWithdrawal(uint amount) { // Isn't clear that this function is potentially unsafe
-    UntrustedBank.withdraw(amount);
+    Bank.withdraw(amount);
 }
 
 // good


### PR DESCRIPTION
Fix up confusing example. The bad example uses a Bank contract so it should be referred to in the makeWithdrawal method as Bank, not UntrustedBank