### PR TITLE
Updates for Solidity 0.4.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ In Solidity 0.4.10 `assert()` and `require()` were introduced. `require(conditio
 
 ### Be aware of the tradeoffs between abstract contracts and interfaces
 
-Both interfaces and abstract contracts provide one with a customizable and re-usable approach for smart contracts. Interfaces, which were introduced in Solidity 0.4.11, are similar to abstract contracts but cannot have any functions implemented. Interfaces also have limitations such as not being able to access storage or inherit  from other interfaces which generally makes abstract contracts more practical. Although, Interfaces are certainly useful for designing contracts prior to implementation. Additionally, it is important to keep in mind that if a contract inherits from an abstract contract it must implement all non-implemented functions via overriding or it will be abstract as well. 
+Both interfaces and abstract contracts provide one with a customizable and re-usable approach for smart contracts. Interfaces, which were introduced in Solidity 0.4.11, are similar to abstract contracts but cannot have any functions implemented. Interfaces also have limitations such as not being able to access storage or inherit from other interfaces which generally makes abstract contracts more practical. Although, Interfaces are certainly useful for designing contracts prior to implementation. Additionally, it is important to keep in mind that if a contract inherits from an abstract contract it must implement all non-implemented functions via overriding or it will be abstract as well. 
 
 ### In 2-party or N-party contracts, beware of the possibility that some participants may "drop offline" and not return
 

--- a/README.md
+++ b/README.md
@@ -125,31 +125,31 @@ Calls to untrusted contracts can introduce several unexpected risks or errors. E
 
 <a name="send-vs-call-value"></a>
 
-#### Be aware of the tradeoffs between `send()` and `call.value()()`
+#### Be aware of the tradeoffs between `send()`, `transfer()`, and `call.value()()`
 
 When sending Ether be aware of the relative tradeoffs between the use of
-`someAddress.send()` and `someAddress.call.value()()`.
+`someAddress.send()`, `someAddress.transfer()`, and `someAddress.call.value()()`.
 
-- `someAddress.send()` is considered *safe* against [reentrancy](#reentrancy).
-    While this method still triggers code execution, the called contract is
+- `x.transfer(y)` is equivalent to `if (!x.send(y)) throw;` Send is the low level counterpart of transfer, and it's advisable to use      transfer when possible.
+- `someAddress.send()`and `someAddress.transfer()` are considered *safe* against [reentrancy](#reentrancy).
+    While these methods still trigger code execution, the called contract is
     only given a stipend of 2,300 gas which is currently only enough to log an
     event.
 - `someAddress.call.value()()` will send the provided ether and trigger code
     execution.  The executed code is given all available gas for execution
     making this type of value transfer *unsafe* against reentrancy.
 
-Using `send()` will prevent reentrancy but it does so at the cost of being
+Using `send()` or `transfer()` will prevent reentrancy but it does so at the cost of being
 incompatible with any contract whose fallback function requires more than 2,300
 gas.  
 
 One pattern that attempts to balance this trade-off is to implement both
-a [*push* and *pull*](#favor-pull-over-push-payments) mechanism, using `send()`
+a [*push* and *pull*](#favor-pull-over-push-payments) mechanism, using `send()` or `transfer()`
 for the *push* component and `call.value()()` for the *pull* component.
 
-It is worth pointing out that exclusive use of `send()` for value transfers
+It is worth pointing out that exclusive use of `send()` or `transfer()` for value transfers
 does not itself make a contract safe against reentrancy, but only makes those
 specific value transfers safe against reentrancy.
-
 
 <a name="handle-external-errors"></a>
 
@@ -300,6 +300,14 @@ Examples:
 * When developing an application that depends on a random number generator, the order should always be (1) players submit moves, (2) random number generated, (3) players paid out. The method by which random numbers are generated is itself an area of active research; current best-in-class solutions include Bitcoin block headers (verified through http://btcrelay.org), hash-commit-reveal schemes (ie. one party generates a number, publishes its hash to "commit" to the value, and then reveals the value later) and [RANDAO](http://github.com/randao/randao).
 * If you are implementing a frequent batch auction, a hash-commit scheme is also desirable.
 
+### Use assert and require properly
+
+In Solidity 0.4.10 `assert()` and `require()` were introduced. `require(condition)` is meant to be used for input validation, which should be done on any user input, and throws if condition is false. `assert(condition)` also throws if condition is false but should be used only for internal errors or to check if your contract has reached an invalid state. By following this paradigm it allows one to use a formal analysis tool, that verifies that the invalid opcode can never be reached, for the absense of errors assuming valid inputs. 
+
+### Be aware of the tradeoffs between abstract contracts and interfaces
+
+Both interfaces and abstract contracts provide one with a customizable and re-usable approach for smart contracts. Interfaces, which were introduced in Solidity 0.4.11, are similar to abstract contracts but cannot have any functions implemented. Interfaces also have limitations such as not being able to access storage or inhereit from other interfaces which generally makes abstract contracts more practical. Although, Interfaces are certainly useful for designing contracts prior to implementation. Additionally, it is important to keep in mind that if a contract inherits from an abstract contract it must implement all non-implemented functions via overriding or it will be abstract as well. 
+
 ### In 2-party or N-party contracts, beware of the possibility that some participants may "drop offline" and not return
 
 Do not make refund or claim processes dependent on a specific party performing a particular action with no other way of getting the funds out. For example, in a rock-paper-scissors game, one common mistake is to not make a payout until both players submit their moves; however, a malicious player can "grief" the other by simply never submitting their move - in fact, if a player sees the other player's revealed move and determiners that they lost, they have no reason to submit their own move at all. This issue may also arise in the context of state channel settlement. When such situations are an issue, (1) provide a way of circumventing non-participating participants, perhaps through a time limit, and (2) consider adding an additional economic incentive for participants to submit information in all of the situations in which they are supposed to do so.
@@ -308,7 +316,7 @@ Do not make refund or claim processes dependent on a specific party performing a
 
 ### Keep fallback functions simple
 
-[Fallback functions](http://solidity.readthedocs.io/en/latest/contracts.html#fallback-function) are called when a contract is sent a message with no arguments (or when no function matches), and only has access to 2,300 gas when called from a `.send()`. If you wish to be able to receive Ether from a `.send()`, the most you can do in a fallback function is log an event. Use a proper function if a computation or more gas is required.
+[Fallback functions](http://solidity.readthedocs.io/en/latest/contracts.html#fallback-function) are called when a contract is sent a message with no arguments (or when no function matches), and only has access to 2,300 gas when called from a `.send()` or `.transfer()`. If you wish to be able to receive Ether from a `.send()` or `.transfer()`, the most you can do in a fallback function is log an event. Use a proper function if a computation or more gas is required.
 
 ```
 // bad
@@ -343,7 +351,6 @@ function internalAction() internal {
     // internal code
 }
 ```
-
 
 <a name="beware-division-by-zero"></a>
 

--- a/README.md
+++ b/README.md
@@ -303,11 +303,11 @@ Examples:
 
 ### Use assert and require properly
 
-In Solidity 0.4.10 `assert()` and `require()` were introduced. `require(condition)` is meant to be used for input validation, which should be done on any user input, and throws if condition is false. `assert(condition)` also throws if condition is false but should be used only for internal errors or to check if your contract has reached an invalid state. By following this paradigm it allows one to use a formal analysis tool, that verifies that the invalid opcode can never be reached, for the absense of errors assuming valid inputs. 
+In Solidity 0.4.10 `assert()` and `require()` were introduced. `require(condition)` is meant to be used for input validation, which should be done on any user input, and throws if condition is false. `assert(condition)` also throws if condition is false but should be used only for internal errors or to check if your contract has reached an invalid state. By following this paradigm it allows one to use a formal analysis tool, that verifies that the invalid opcode can never be reached, for the absence of errors assuming valid inputs. 
 
 ### Be aware of the tradeoffs between abstract contracts and interfaces
 
-Both interfaces and abstract contracts provide one with a customizable and re-usable approach for smart contracts. Interfaces, which were introduced in Solidity 0.4.11, are similar to abstract contracts but cannot have any functions implemented. Interfaces also have limitations such as not being able to access storage or inhereit from other interfaces which generally makes abstract contracts more practical. Although, Interfaces are certainly useful for designing contracts prior to implementation. Additionally, it is important to keep in mind that if a contract inherits from an abstract contract it must implement all non-implemented functions via overriding or it will be abstract as well. 
+Both interfaces and abstract contracts provide one with a customizable and re-usable approach for smart contracts. Interfaces, which were introduced in Solidity 0.4.11, are similar to abstract contracts but cannot have any functions implemented. Interfaces also have limitations such as not being able to access storage or inherit  from other interfaces which generally makes abstract contracts more practical. Although, Interfaces are certainly useful for designing contracts prior to implementation. Additionally, it is important to keep in mind that if a contract inherits from an abstract contract it must implement all non-implemented functions via overriding or it will be abstract as well. 
 
 ### In 2-party or N-party contracts, beware of the possibility that some participants may "drop offline" and not return
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ It is worth pointing out that exclusive use of `send()` or `transfer()` for valu
 does not itself make a contract safe against reentrancy, but only makes those
 specific value transfers safe against reentrancy.
 
+
 <a name="handle-external-errors"></a>
 
 #### Handle errors in external calls
@@ -351,6 +352,7 @@ function internalAction() internal {
     // internal code
 }
 ```
+
 
 <a name="beware-division-by-zero"></a>
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Examples:
 
 ### Use assert and require properly
 
-In Solidity 0.4.10 `assert()` and `require()` were introduced. `require(condition)` is meant to be used for input validation, which should be done on any user input, and throws if condition is false. `assert(condition)` also throws if condition is false but should be used only for internal errors or to check if your contract has reached an invalid state. By following this paradigm it allows one to use a formal analysis tool, that verifies that the invalid opcode can never be reached, for the absence of errors assuming valid inputs. 
+In Solidity 0.4.10 `assert()` and `require()` were introduced. `require(condition)` is meant to be used for input validation, which should be done on any user input, and throws if condition is false. `assert(condition)` also throws if condition is false but should be used only for internal errors or to check if your contract has reached an invalid state. By following this paradigm it would become possible to use a formal analysis tool, that verifies that the invalid opcode can never be reached, for the absence of errors assuming valid inputs. 
 
 ### Be aware of the tradeoffs between abstract contracts and interfaces
 


### PR DESCRIPTION
Updated for Solidity 0.4.10 and Solidity 0.4.11. I included information on transfer(), require(), assert(), and the trade-offs between abstract contracts and interfaces. I decided to leave revert() for the metropolis edition as it exhibits the same functionality as throw, for now. 

Please let me know if you have any feedback or changes you would like to see! 