### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Whether using *raw calls* or *contract calls*, assume that malicious code will e
 
 #### Favor *pull* over *push* for external calls
 
-External calls can fail accidentally or deliberately. To minimize the damage caused by such failures, it is often better to isolate each external call into its own transaction that can be initiated by the recipient of the call. This is especially relevant for payments, where it is better to let users withdraw funds rather than push funds to them automatically. (This also reduces the chance of [problems with the gas limit](https://github.com/ConsenSys/smart-contract-best-practices/#dos-with-block-gas-limit).)  Avoid combining or multiple `send()` calls in a single transaction.
+External calls can fail accidentally or deliberately. To minimize the damage caused by such failures, it is often better to isolate each external call into its own transaction that can be initiated by the recipient of the call. This is especially relevant for payments, where it is better to let users withdraw funds rather than push funds to them automatically. (This also reduces the chance of [problems with the gas limit](https://github.com/ConsenSys/smart-contract-best-practices/#dos-with-block-gas-limit).)  Avoid combining multiple `send()` calls in a single transaction.
 
 ```
 // bad


### PR DESCRIPTION
"Avoid combining or multiple send() calls in a single transaction."

to

"Avoid combining multiple send() calls in a single transaction."