### PR TITLE
Began including known attacks from the USCC

### DIFF
--- a/docs/known_attacks.md
+++ b/docs/known_attacks.md
@@ -325,16 +325,12 @@ contract ExampleContract is PretendingToRevert {
 
 Contract users (and auditors) should be aware of the full smart contract source code of any application they intend to use. 
 
-# Fallback Function Bypass
+### Forcibly Sending Ether to a Contract
 
-Fallback function bypasses allow ether to be sent to a contract without triggering its fallback function. This is an important consideration when placing important logic in the fallback function or making calculations based on a contract's balance. Take the following example:
+It is possible to forcibly send Ether to a contract without triggering its fallback function. This is an important consideration when placing important logic in the fallback function or making calculations based on a contract's balance. Take the following example:
 
 ```sol
 contract Vulnerable {
-    function Vulnerable() payable {
-        require(msg.value == 0);
-    }
-
     function () payable {
         revert();
     }
@@ -346,6 +342,10 @@ contract Vulnerable {
 }
 ```
 
-Contract logic seems to disallow payments to the contract and therefore disallow "something bad" from happening. However, a few methods exist for forcibly sending ether to the contract and therefore making the balance greater than zero. The `selfdestruct` contract method allows a user to specify a beneficiary to send any excess ether. `selfdestruct` [does not trigger a contract's fallback function](https://solidity.readthedocs.io/en/develop/security-considerations.html#sending-and-receiving-ether). It is also possible to [precompute](https://github.com/Arachnid/uscc/tree/master/submissions-2017/ricmoo) a contract's address and send ether to that address before deploying the contract.
+Contract logic seems to disallow payments to the contract and therefore disallow "something bad" from happening. However, a few methods exist for forcibly sending ether to the contract and therefore making its balance greater than zero. 
 
-Contract developers should be aware that ether can be forcibly sent to a contract and should design contract logic accordingly. Generally, assume that it is not possible to restrict sources of funding to your contract. 
+The `selfdestruct` contract method allows a user to specify a beneficiary to send any excess ether. `selfdestruct` [does not trigger a contract's fallback function](https://solidity.readthedocs.io/en/develop/security-considerations.html#sending-and-receiving-ether). 
+
+It is also possible to [precompute](https://github.com/Arachnid/uscc/tree/master/submissions-2017/ricmoo) a contract's address and send Ether to that address before deploying the contract.
+
+Contract developers should be aware that Ether can be forcibly sent to a contract and should design contract logic accordingly. Generally, assume that it is not possible to restrict sources of funding to your contract. 

--- a/docs/known_attacks.md
+++ b/docs/known_attacks.md
@@ -306,3 +306,46 @@ You will need to make sure that nothing bad will happen if other transactions ar
 ### ~~Call Depth Attack~~
 
 As of the [EIP 150](https://github.com/ethereum/EIPs/issues/150) hardfork, call depth attacks are no longer relevant<sup><a href='http://ethereum.stackexchange.com/questions/9398/how-does-eip-150-change-the-call-depth-attack'>\*</a></sup> (all gas would be consumed well before reaching the 1024 call depth limit).
+
+### Built-in Shadowing
+
+It is currently possible to [shadow](https://en.wikipedia.org/wiki/Variable_shadowing) built-in globals in Solidity. This allows contracts to override the functionality of built-ins such as `msg` and `revert()`. Although this [is intended](https://github.com/ethereum/solidity/issues/1249), it can mislead users of a contract as to the contract's true behavior.
+
+```sol
+contract PretendingToRevert {
+    function revert() internal constant {}
+}
+
+contract ExampleContract is PretendingToRevert {
+    function somethingBad() public {
+        revert();
+    }
+}
+```
+
+Contract users (and auditors) should be aware of the full smart contract source code of any application they intend to use. 
+
+# Fallback Function Bypass
+
+Fallback function bypasses allow ether to be sent to a contract without triggering its fallback function. This is an important consideration when placing important logic in the fallback function or making calculations based on a contract's balance. Take the following example:
+
+```sol
+contract Vulnerable {
+    function Vulnerable() payable {
+        require(msg.value == 0);
+    }
+
+    function () payable {
+        revert();
+    }
+    
+    function somethingBad() {
+        require(this.balance > 0);
+        // Do something bad
+    }
+}
+```
+
+Contract logic seems to disallow payments to the contract and therefore disallow "something bad" from happening. However, a few methods exist for forcibly sending ether to the contract and therefore making the balance greater than zero. The `selfdestruct` contract method allows a user to specify a beneficiary to send any excess ether. `selfdestruct` [does not trigger a contract's fallback function](https://solidity.readthedocs.io/en/develop/security-considerations.html#sending-and-receiving-ether). It is also possible to [precompute](https://github.com/Arachnid/uscc/tree/master/submissions-2017/ricmoo) a contract's address and send ether to that address before deploying the contract.
+
+Contract developers should be aware that ether can be forcibly sent to a contract and should design contract logic accordingly. Generally, assume that it is not possible to restrict sources of funding to your contract. 


### PR DESCRIPTION
I'm slowly adding in topics and lessons learned from the [USCC](https://medium.com/@chriseth/lessons-learnt-from-the-underhanded-solidity-contest-8388960e09b1) as per https://github.com/ConsenSys/smart-contract-best-practices/issues/102. This pull request includes documentation of built-in shadowing and fallback function bypassing. Forced sending of ether to a contract is briefly mentioned in [Recommendations](https://github.com/ConsenSys/smart-contract-best-practices/blob/cea931b36466b4202927adad7072669a030290d3/docs/recommendations.md), although this addition expands on possible attack surfaces. Feedback is welcome.