### PR TITLE
Fix bug in `Pitfalls in Race Condition Solutions`

### DIFF
--- a/docs/known_attacks.md
+++ b/docs/known_attacks.md
@@ -104,7 +104,7 @@ function untrustedWithdraw(address recipient) public {
 }
 
 function untrustedGetFirstWithdrawalBonus(address recipient) public {
-    require(claimedBonus[recipient]); // Each recipient should only be able to claim the bonus once
+    require(!claimedBonus[recipient]); // Each recipient should only be able to claim the bonus once
 
     claimedBonus[recipient] = true;
     rewardsForA[recipient] += 100;


### PR DESCRIPTION
The require condition was flipped between examples.

It should require that the bonus hasn't been claimed yet.