### PR TITLE
Fix [contributing] link at READMD.md and [docs] link at contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Read the docs in Chinese: https://github.com/ConsenSys/smart-contract-best-pract
 
 ## Contributions are welcome!
 
-Feel free to submit a pull request, with anything from small fixes, to full new sections. If you are writing new content, please reference the [contributing](./about/contributing) page for guidance on style. 
+Feel free to submit a pull request, with anything from small fixes, to full new sections. If you are writing new content, please reference the [contributing](./docs/about/contributing.md) page for guidance on style. 
 
 See the [issues](https://github.com/ConsenSys/smart-contract-best-practices/issues) for topics that need to be covered or updated. If you have an idea you'd like to discuss, please chat with us in [Gitter](https://gitter.im/ConsenSys/smart-contract-best-practices).
 

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -5,7 +5,7 @@ Feel free to peruse the [open issues](https://github.com/ConsenSys/smart-contrac
 ## Editing and Submitting changes
 
 1. Fork the repo
-2. Make changes to the markdown files in the [docs directory](../tree/master/docs) of the master branch
+2. Make changes to the markdown files in the [docs directory](../../../../tree/master/docs) of the master branch
 3. Submit a Pull Request
 
 ## Audience


### PR DESCRIPTION
Fixing 2 links:

- At README.md file:

Update the link of "contributing" file:
./about/contributing
to be:
./docs/about/contributing.md

- At contributing.md file:

Update the link of [docs directory] file:
../tree/master/docs
to be:
../../../../tree/master/docs