### PR TITLE
Fix insecure mutex example

### DIFF
--- a/docs/known_attacks.md
+++ b/docs/known_attacks.md
@@ -147,7 +147,7 @@ If the user tries to call `withdraw()` again before the first call finishes, the
 ```sol
 // INSECURE
 contract StateHolder {
-    uint private n;
+    uint public n;
     address private lockHolder;
 
     function getLock() {
@@ -156,6 +156,7 @@ contract StateHolder {
     }
 
     function releaseLock() {
+        require(msg.sender == lockHolder);
         lockHolder = 0;
     }
 


### PR DESCRIPTION
This is a small fix for the insecure mutex contract example.

I believe this way it corresponds better to the text. In the original version anyone can call `releaseLock()`, which prevents the described attack scenario ("locked forever").