### PR TITLE
Updated reference to timing rule

### DIFF
--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -418,7 +418,7 @@ modifier auction_complete {
           currentAuctionState == AuctionState.cancel)
         _;}
 ```
-`block.number` and *[average block time](https://etherscan.io/chart/blocktime)* can be used to estimate time as well, but this is not future proof as block times may change (such as [fork reorganisations](https://blog.ethereum.org/2015/08/08/chain-reorganisation-depth-expectations/) and the [difficulty bomb](https://github.com/ethereum/EIPs/issues/649)). In a sale spanning days, the 12-minute rule allows one to construct a more reliable estimate of time. 
+`block.number` and *[average block time](https://etherscan.io/chart/blocktime)* can be used to estimate time as well, but this is not future proof as block times may change (such as [fork reorganisations](https://blog.ethereum.org/2015/08/08/chain-reorganisation-depth-expectations/) and the [difficulty bomb](https://github.com/ethereum/EIPs/issues/649)). In a sale spanning days, the 30-second rule allows one to construct a more reliable estimate of time. 
 
 ## Multiple Inheritance Caution
 


### PR DESCRIPTION
Was just reading the docs, it seems that advice has been updated regarding the safe time to use the timestamp - from 12 minutes down to 30s. This might be an error in the following section, which I've updated.