### PR TITLE
Add "Don't use modifiers for external calls"

### DIFF
--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -160,6 +160,35 @@ contract Worker
 
 If `Worker.doWork()` is called with the address of the deployed `Destructor` contract as an argument, the `Worker` contract will self-destruct. Delegate execution only to trusted contracts, and never to a user supplied address.
 
+### Don't use modifiers for external calls
+
+Function modifiers are usually executed before the function body. That means that if a modifier includes state change or external call, it will be called before other checks that might be required.
+
+```sol
+contract Registry
+{
+    address owner;
+    
+    function isVoter(address _addr) external returns(bool) {
+        // Code
+    }
+}
+
+contract Election
+{
+    modifier isEligible(address _addr) {
+        require(registry.isVoter(_addr));
+        _;
+    }
+    
+    function vote() isEligible(msg.sender) public {
+        // Code
+    }
+}
+```
+
+In this case, contract `Registry` can make a reentracy attack by calling `Election.vote()` inside `isVoter()`.
+
 ## Don't assume contracts are created with zero balance
 
 An attacker can send wei to the address of a contract before it is created.  Contracts should not assume that its initial state contains a zero balance.  See [issue 61](https://github.com/ConsenSys/smart-contract-best-practices/issues/61) for more details.

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -213,7 +213,7 @@ In Solidity 0.4.10 `assert()` and `require()` were introduced. `require(conditio
 
 ## Use modifiers only for assertions
 
-The code inside modifiers is usually executed before the function body, so any state changes or external calls will violate the [Checks-Effects-Interactions](https://solidity.readthedocs.io/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern) pattern. Moreover, these statements may also remain unnoticed by the developer, as the code for modifier may be far from the function declaration. For example, an external call in modifier can lead to the reentrancy attack:
+The code inside a modifier is usually executed before the function body, so any state changes or external calls will violate the [Checks-Effects-Interactions](https://solidity.readthedocs.io/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern) pattern. Moreover, these statements may also remain unnoticed by the developer, as the code for modifier may be far from the function declaration. For example, an external call in modifier can lead to the reentrancy attack:
 
 ```sol
 contract Registry {
@@ -225,6 +225,8 @@ contract Registry {
 }
 
 contract Election {
+    Registry registry;
+    
     modifier isEligible(address _addr) {
         require(registry.isVoter(_addr));
         _;
@@ -236,7 +238,7 @@ contract Election {
 }
 ```
 
-In this case, `Registry` contract can make a reentracy attack by calling `Election.vote()` inside `isVoter()`.
+In this case, the `Registry` contract can make a reentracy attack by calling `Election.vote()` inside `isVoter()`.
 
 Use modifiers only for [error handling](https://solidity.readthedocs.io/en/develop/control-structures.html#error-handling-assert-require-revert-and-exceptions).
 


### PR DESCRIPTION
Fixes #133.

Original issue talks about both state changes and external calls. I decided to focus here solely on the external calls here. 

However, I looked at a bunch of smart contracts and some libraries, and 95% of them are one or few `require` statements. The only modifiers that change state that I found is "Reentrancy guard" of some kind.

So maybe we should make this section even more strict by forbidding / discouraging state changes in modifiers except for a few cases (like reentracy protection). (and therefore move it from "External calls" section)

Please tell me your thoughts on this and whether I need to elaborate more here.