### PR TITLE
Add bad usage of EXTCODESIZE

### DIFF
--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -602,8 +602,8 @@ contract Auction is TypeSafeAuction {
 }
 ```
 ## Avoid using `extcodesize` to check for EOAs
-Often the following modifier (or a similar check) is used to verify whether a call was made from an externally owned account or a contract account:
-```
+Often the following modifier (or a similar check) is used to verify whether a call was made from an externally owned account (EOA) or a contract account:
+```sol
 // bad
 modifier isNotContract(address _a) {
   uint size;
@@ -615,7 +615,7 @@ modifier isNotContract(address _a) {
 }
 ```
 The idea is simple: if an address has associated code to it, it's not an EOA but a contract account. However, a contract does not have source code available during construction. This means that while the constructor is running, `extcodesize` for that address returns zero. Below is a minimal example that shows how this can be exploited:
-```
+```sol
 contract OnlyForEOA {    
     uint public flag;
     

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -601,8 +601,10 @@ contract Auction is TypeSafeAuction {
     }
 }
 ```
-## Avoid using `extcodesize` to check for EOAs
+## Avoid using `extcodesize` to check for Externally Owned Accounts
+
 Often the following modifier (or a similar check) is used to verify whether a call was made from an externally owned account (EOA) or a contract account:
+
 ```sol
 // bad
 modifier isNotContract(address _a) {
@@ -614,7 +616,9 @@ modifier isNotContract(address _a) {
      _;
 }
 ```
+
 The idea is simple: if an address has associated code to it, it's not an EOA but a contract account. However, a contract does not have source code available during construction. This means that while the constructor is running, `extcodesize` for that address returns zero. Below is a minimal example that shows how this can be exploited:
+
 ```sol
 contract OnlyForEOA {    
     uint public flag;

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -627,7 +627,7 @@ contract OnlyForEOA {
         _;
     }
     
-    function setFlag(uint i) public isConscious(msg.sender){
+    function setFlag(uint i) public isNotContract(msg.sender){
         flag = i;
     }
 }


### PR DESCRIPTION
Added a small write-up of how `extcodesize` should not be used for verifying externally owned accounts, which unfortunately is fairly common and easily exploitable [[1](https://www.reddit.com/r/ethereum/comments/916xni/how_to_pwn_fomo3d_a_beginners_guide/)].