### PR TITLE
Minor fixes

### DIFF
--- a/docs/bug_bounty_list.md
+++ b/docs/bug_bounty_list.md
@@ -8,7 +8,7 @@ The following are ongoing bug bounty programs, either focused on, or including s
 * [BrickBlock](https://blog.brickblock.io/join-the-brickblock-bug-bounty-program-7b431f2bcc02): Launched September 2018, Max payout 100 ETH
 * [MelonPort](https://melonport.com/bug-bounty)
 * [Parity](https://www.parity.io/bug-bounty/): Includes client and contract code
-* [Ethereum Foundation](https://bounty.ethereum.org/#bounty-scope): Has a large scope, including clients, soldity and vyper, and more.
+* [Ethereum Foundation](https://bounty.ethereum.org/#bounty-scope): Has a large scope, including clients, Solidity and Vyper, and more.
 
 
 

--- a/docs/known_attacks.md
+++ b/docs/known_attacks.md
@@ -247,7 +247,7 @@ contract UnderflowManipulation {
  
 In general, the variable `manipulateMe`'s location cannot be influenced without going through the `keccak256`, which is infeasible. However, since dynamic arrays are stored sequentially, if a malicious actor wanted to change `manipulateMe` all they would need to do is:
  
- * Call `popBonusCode` to underflow (Note: Solidity [lacks a built-in pop method](https://github.com/ethereum/solidity/pull/3743))
+ * Call `popBonusCode` to underflow (Note: `array.pop()` method [was added](https://github.com/ethereum/solidity/blob/v0.5.0/Changelog.md) in Solidity 0.5.0)
  * Compute the storage location of `manipulateMe`
  * Modify and update `manipulateMe`'s value using `modifyBonusCode`
 

--- a/docs/known_attacks.md
+++ b/docs/known_attacks.md
@@ -378,7 +378,7 @@ An attacker can use this to censor transactions, causing them to fail by sending
 
 One way to address this is to implement logic requiring forwarders to provide enough gas to finish the subcall. If the miner tried to conduct the attack in this scenario, the `require` statement would fail and the inner call would revert. A user can specify a minimum gasLimit along with the other data (in this example, typically the `_gasLimit` value would be verified by a signature, but that is ommitted for simplicity in this case).
 
-```
+```sol
 // contract called by Relayer
 contract Executor {
     function execute(bytes _data, uint _gasLimit) {

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -456,9 +456,7 @@ Contract users (and auditors) should be aware of the full smart contract source 
 
 Never use `tx.origin` for authorization, another contract can have a method which will call your contract (where the user has some funds for instance) and your contract will authorize that transaction as your address is in `tx.origin`.
 
-```
-pragma solidity 0.4.18;
-
+```sol
 contract MyContract {
 
     address owner;


### PR DESCRIPTION
Fixed a typo and added missing `sol` labels for code snippets.

Also, updated note about lacking `pop` method.