### PR TITLE
Fix 本文翻译自 hyperlink at README-zh.md

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,6 +1,6 @@
 # 以太坊智能合约 —— 最佳安全开发指南
 
-*本文翻译自：https://github.com/ConsenSys/smart-contract-best-practices。
+*本文翻译自：https://github.com/ConsenSys/smart-contract-best-practices
 为了使语句表达更加贴切，个别地方未按照原文逐字逐句翻译，如有出入请以原文为准。*
 
 [![Join the chat at https://gitter.im/ConsenSys/smart-contract-best-practices](https://badges.gitter.im/ConsenSys/smart-contract-best-practices.svg)](https://gitter.im/ConsenSys/smart-contract-best-practices?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION

*本文翻译自：https://github.com/ConsenSys/smart-contract-best-practices。
this dots in the end of link make wrong link when click
