### PR TITLE
Update example code for solidity v5

### DIFF
--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -236,7 +236,7 @@ contract Token {
     function deposit() public payable {
         balanceOf[msg.sender] += msg.value;
         totalSupply += msg.value;
-        assert(this.balance >= totalSupply);
+        assert(address(this).balance >= totalSupply);
     }
 }
 ```


### PR DESCRIPTION
Querying the balance like so:

```solidity
this.balance
```

Yields the following error in solidity v5 and above:

> Member "balance" not found or not found after argument-dependent lookup in contract ContractName.sol

Should be like this:

```solidity
address(this).balance
```