### PR TITLE
Update Aragon Bug Bounty link

### DIFF
--- a/docs/bug_bounty_list.md
+++ b/docs/bug_bounty_list.md
@@ -2,7 +2,7 @@
 The following are ongoing bug bounty programs, either focused on, or including smart contracts in their scope. Issues and PRs are welcome to add new bounties, or remove those which are no longer active.
 
 * [Airswap](https://medium.com/fluidity/smart-contracts-and-bug-bounty-ad75733eb53f)
-* [Aragon](https://wiki.aragon.org/association/security/bug_bounty/)
+* [Aragon](https://wiki.aragon.org/association/security/#smart-contract-bug-bounty)
 * [Augur](https://www.augur.net/bounty/): Launched October 2018, Max payout $250k
 * [BrickBlock](https://blog.brickblock.io/join-the-brickblock-bug-bounty-program-7b431f2bcc02): Launched September 2018, Max payout 100 ETH
 * [Colony.io](https://blog.colony.io/announcing-the-colony-network-bug-bounty-f44cabaca9a3/)


### PR DESCRIPTION
The Aragon Association has two separate bug bounties available (one for the client and one for the court), so I just updated the link to the heading where we list both of the bounties rather than their own separate pages.