### PR TITLE
Update Integer Overflow with Solidity v. 0.8.0

### DIFF
--- a/docs/known_attacks.md
+++ b/docs/known_attacks.md
@@ -332,7 +332,7 @@ Be careful with the smaller data-types like uint8, uint16, uint24...etc: they ca
 !!! Warning
     Be aware there are around [20 cases for overflow and underflow](https://github.com/ethereum/solidity/issues/796#issuecomment-253578925).
 
-One simple solution to mitigate the common mistakes for overflow and underflow is to use `SafeMath.sol` [library](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/math/SafeMath.sol) for arithmetic functions. Solidity automatically reverts on integer overflow and underflow, as of version 8.0.0.
+One simple solution to mitigate the common mistakes for overflow and underflow is to use `SafeMath.sol` [library](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/math/SafeMath.sol) for arithmetic functions. Solidity automatically reverts on integer overflow and underflow, as of version 0.8.0.
 
 See [SWC-101](https://swcregistry.io/docs/SWC-101)
 

--- a/docs/known_attacks.md
+++ b/docs/known_attacks.md
@@ -332,7 +332,7 @@ Be careful with the smaller data-types like uint8, uint16, uint24...etc: they ca
 !!! Warning
     Be aware there are around [20 cases for overflow and underflow](https://github.com/ethereum/solidity/issues/796#issuecomment-253578925).
 
-One simple solution to mitigate the common mistakes for overflow and underflow is to use `SafeMath.sol` [library](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/math/SafeMath.sol) for arithmetic functions.
+One simple solution to mitigate the common mistakes for overflow and underflow is to use `SafeMath.sol` [library](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/math/SafeMath.sol) for arithmetic functions. Solidity automatically reverts on integer overflow and underflow, as of version 8.0.0.
 
 See [SWC-101](https://swcregistry.io/docs/SWC-101)
 


### PR DESCRIPTION
Solidity will automatically revert on integer overflow and underflow since v. 8.0.0, should be included as a way to mitigate such attacks.