### PR TITLE
Update terminology from deprecated timestamp keyword

### DIFF
--- a/docs/software_engineering.md
+++ b/docs/software_engineering.md
@@ -183,13 +183,13 @@ function requestWithdrawal() public {
 
         requestedWithdrawals[msg.sender] = RequestedWithdrawal({
             amount: amountToWithdraw,
-            time: now
+            time: block.timestamp
         });
     }
 }
 
 function withdraw() public {
-    if(requestedWithdrawals[msg.sender].amount > 0 && now > requestedWithdrawals[msg.sender].time + withdrawalWaitPeriod) {
+    if(requestedWithdrawals[msg.sender].amount > 0 && block.timestamp > requestedWithdrawals[msg.sender].time + withdrawalWaitPeriod) {
         uint amountToWithdraw = requestedWithdrawals[msg.sender].amount;
         requestedWithdrawals[msg.sender].amount = 0;
 


### PR DESCRIPTION
**Background** 
With the release of Solidity 0.7.0, one of the [listed breaking changes](https://docs.soliditylang.org/en/v0.7.0/070-breaking-changes.html) is the following:

- "The global variable `now` is deprecated, `block.timestamp` should be used instead. The single identifier `now` is too generic for a global variable and could give the impression that it changes during transaction processing, whereas `block.timestamp` correctly reflects the fact that it is just a property of the block."

**Problem**
Under the software engineering techniques section of the documentation, specifically the [Speed Bumps section](https://consensys.github.io/smart-contract-best-practices/software_engineering/#speed-bumps-delay-contract-actions), we use this deprecated keyword.

**Solution**
Replace `now` with `block.timestamp`. 
