### PR TITLE
Note added to commit-reveal recommendation

### DIFF
--- a/docs/development-recommendations/general/public-data.md
+++ b/docs/development-recommendations/general/public-data.md
@@ -6,6 +6,10 @@ requiring users to publish information too early. The best strategy is to use
 [commitment schemes](https://en.wikipedia.org/wiki/Commitment_scheme) with separate phases: first
 commit using the hash of the values and in a later phase revealing the values.
 
+However, care must be taken to ensure that the hashed value stored isn't recognisable (and thus, de-mappable), as this would defeat the second purpose of hashing - preventing the reveal of such values. Here's an example:
+
+Say a smart contract allows 2 players to play rock-paper-scissors, and uses this commit-reveal scheme - both players have to send a hash of their move before either of them sends the last (game ending) transaction. Here's what the keccak256 hash of `rock` is: `10977e4d68108d418408bc9310b60fc6d0a750c63ccef42cfb0ead23ab73d102`. If you were playing, and you saw your opponent commiting this, wouldn't this tell you exactly what move your opponent has committed to? A safer implementation would be to hash not just the name of the move, but also, say, a user chosen salt. That would make the resulting salt non-recognisable.
+
 Examples:
 
 - In rock paper scissors, require both players to submit a hash of their intended move first, then


### PR DESCRIPTION
The commit-reveal scheme must be implemented in such a way that what user commits is non-recognisable, so it's not publicly 'guessable'.

This PR pushes a note about this, plus an example.