### PR TITLE
Add Contributing link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Read the docs in Vietnamese: https://github.com/ConsenSys/smart-contract-best-pr
 
 ## Contributions are welcome!
 
-Feel free to submit a pull request, with anything from small fixes, to full new sections. If you are writing new content, please reference the [contributing](./docs/about/index.md) page for guidance on style.
+Feel free to submit a pull request, with anything from small fixes, to full new sections. If you are writing new content, please reference the [contributing](https://github.com/pucedoteth/smart-contract-best-practices/blob/master/CONTRIBUTING.md) page for guidance on style.
 
 See the [issues](https://github.com/ConsenSys/smart-contract-best-practices/issues) for topics that need to be covered or updated. If you have an idea you'd like to discuss, please chat with us in [Gitter](https://gitter.im/ConsenSys/smart-contract-best-practices).
 


### PR DESCRIPTION
when you click on Contributing in README, it should take you to the right contributing page. i fixed that by adding the right link.