### PR TITLE
Fix grammatical errors and improve documentation clarity

### DIFF
--- a/docs/attacks/denial-of-service.md
+++ b/docs/attacks/denial-of-service.md
@@ -19,7 +19,7 @@ contract Auction {
 }
 ```
 
-If attacker bids using a smart contract which has a fallback function that reverts any payment, the
+If an attacker bids using a smart contract which has a fallback function that reverts any payment, the
 attacker can win any auction. When it tries to refund the old leader, it reverts if the refund
 fails. This means that a malicious bidder can become the leader while making sure that any refunds
 to their address will *always* fail. In this way, they can prevent anyone else from calling the
@@ -53,7 +53,7 @@ See [SWC-113](https://swcregistry.io/docs/SWC-113)
 ## DoS with Block Gas Limit
 
 Each block has an upper bound on the amount of gas that can be spent, and thus the amount
-computation that can be done. This is the Block Gas Limit. If the gas spent exceeds this limit, the
+computations that can be done. This is the Block Gas Limit. If the gas spent exceeds this limit, the
 transaction will fail. This leads to a couple of possible Denial of Service vectors:
 
 ### Gas Limit DoS on a Contract via Unbounded Operations

--- a/docs/attacks/deprecated.md
+++ b/docs/attacks/deprecated.md
@@ -15,7 +15,7 @@ On January 16th, 2019, Constantinople protocol upgrade was delayed due to a secu
 enabled by [EIP 1283](https://eips.ethereum.org/EIPS/eip-1283). _EIP 1283: Net gas metering for
 SSTORE without dirty maps_ proposes changes to reduce excessive gas costs on dirty storage writes.
 
-This change led to possibility of a new reentrancy vector making previously known secure withdrawal
+This change led to the possibility of a new reentrancy vector making previously known secure withdrawal
 patterns (`.send()` and `.transfer()`) unsafe in specific
 situations<sup><a href='https://medium.com/chainsecurity/constantinople-enables-new-reentrancy-attack-ace4088297d9'>\*</a></sup>,
 where the attacker could hijack the control flow and use the remaining gas enabled by EIP 1283,

--- a/docs/attacks/timestamp-dependence.md
+++ b/docs/attacks/timestamp-dependence.md
@@ -3,6 +3,6 @@ indirect uses of the timestamp should be considered.
 
 !!! Note
     See the [Recommendations](../development-recommendations/solidity-specific/timestamp-dependence.md) section for design
-    considerations related to Timestamp Dependence.
+    considerations related to the Timestamp Dependence.
 
     See [SWC-116](https://swcregistry.io/docs/SWC-116)

--- a/docs/development-recommendations/deprecated/functions-and-events.md
+++ b/docs/development-recommendations/deprecated/functions-and-events.md
@@ -6,9 +6,9 @@
 
 Favor capitalization and a prefix in front of events (we suggest *Log*), to prevent the risk of
 confusion between functions and events. For functions, always start with a lowercase letter, except
-for the constructor.
+for the a constructor.
 
-```sol
+```solidity
 // bad
 event Transfer() {}
 function transfer() {}


### PR DESCRIPTION
1. **denial-of-service.md**:
   - Added missing article "an" before "attacker".
   - Corrected "computation" to "computations" for consistency.

2. **deprecated.md**:
   - Improved sentence structure for better readability.

3. **timestamp-dependence.md**:
   - Added "the" before "Timestamp Dependence" for consistency.

4. **functions-and-events.md**:
   - Added "a" before "constructor" for grammatical accuracy.
   - Changed code block language from "sol" to "solidity" for better syntax highlighting.
